### PR TITLE
Add custom palette support and sputnik

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,13 @@ android:
 script:
  - ./gradlew build
  - ./gradlew test
+ 
+before_install:
+  - python <(curl -s https://raw.githubusercontent.com/TouK/sputnik-ci/master/sputnik-ci.py)
+
+env:
+  global:
+  - secure: PIbHGVr+Bv0HbK6qOE6C0FrVqcsm/Q6kzFCOa4y9ixT8+2i82DDP4kyyy2ymKevmps+7+SCeJiW8KQkZa7gztSG0h1BoHJo0C6f0xiMYG4kY/7Gq4ZX3mehOVFUymxqhVED/NMK4a7JJxqcSH7JIkBLkuEaueqxc3CmHjI7LCqTr9yMdu/8ulhOeEL/Drg0zsNK9424K6BtxnTh6nNmbNfRnvxCgFc3mLuZ4J6/YN7lBagNiBhpr3XsXdvUC/W89UCcQCIkl/xBKPTxoUGxD6YG+IhapEJrQvqsFkvwFcsUUa9iL7+23QDlK7VGXeKZxwcMYWjRSVai3np94cHZwqivL1okoMFnIjqcAAzX5NOgd0VvM1dUqIwkXQDhp9IPGqDe/H1BiuRb8rmbJyRsxx5YjwksuPugDcG/B24qhyz4NM+gupMx0UE1DXS20xtE1kItEMzCyOJGXDwD9VR13ED0kYkcZoovPFdGFUOpAyAE9UYe1wDpDbmxF8o24tM5ICTcaATpiowWvBmS3i2qsEg8akpxmOqwWK//aOg2aNRiiX5we1H8QK8QNT0MoRf7B9bh59BHL6aOJ/jCeiYXb1jjWGQCGO9Vh3lzJWw2V9f2CvnUaZfeJOCzLgVPqtrI9E1LoPLiVT0Izx9DZ+aINrBxhNfndz5UZ4VQPHF8DDe4=
 
 notifications:
   slack: sdsmdg:hvFSzqFNHm3t6NDR2H2Twiio

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Google Play Store link for demo app | [link](https://suyashmahar.me/404)
     3. [Generates](#23-Generates)
     4. [Note on Units of CellSize, Variance, Bleed & Grid Height](#24-note-on-units-of-cellsize-variance-bleed-and-grid-height)
     5. [Setting Palette using `.setPalette()`](#25-setting-palette-using-setpalette-method)
+    6. [Using custom Palettes](#26-using-custom-palettes)
 3. [Performance analysis](#3-performance-analysis)
 4. [Known issues and bugs](#4-known-issues-and-bugs)
 5. [UML Diagrams](#5-uml-diagrams)
@@ -50,7 +51,7 @@ import com.sdsmdg.kd.trianglify.views.TrianglifyView;
 import com.sdsmdg.kd.trianglify.models.Palette;
 ```
 
-Code for using TrianglifyView  
+Java code for using TrianglifyView  
 
 ```java
 trianglifyView = (TrianglifyView) findViewById(R.id.trianglify_main_view); 
@@ -61,8 +62,8 @@ trianglifyView.setGridWidth(trianglifyView.getWidth())
             .setCellSize(20)
             .setVariance(10)
             .setTypeGrid(0)
-            .setPalette(26)
-            .setDrawStrokeEnabled(false);
+            .setPalette(Palette.getPalette(26))
+            .setDrawStrokeEnabled(true);
 ```
 ### 1.2 XML
 ```xml
@@ -130,10 +131,29 @@ public int pxToDp(int px) {
 }
 ```
 ### 2.5 Setting Palette using setPalette method
-`TrianglifyView`'s `.setPalette()` accepts integer that corresponds to index of palette in `com.sdsmdg.kd.trianglify.models.Palette.java` which is an enum. Palette can be set using one of the following method: 
-* To use specific palette for example *Spectral* use `trianglifyView.setPalette(Palette.Spectral)`
-* To use palette referring to its index for example palette at index `<index>` of `Palette.java` enum use `.setPalette(Palette.values()[<index>])`  
-> **Note:** Palette enum defines total of 28 named palettes that can be accessed using either of the above defined methods.
+`TrianglifyView`'s `setPalette` method accepts `Palette` object. Palette can be set using one of the following method: 
+* To use one of the predefined palette, for example **Spectral** use `trianglifyView.setPalette(Palette.getPalette(Palette.Spectral))`.
+* To use palette referring to its index use `Palette.getPalette(<index>)`.  
+* To use custom palette refer to section [2.6 Using custom Palettes](#26-using-custom-palettes).
+
+> **Note:** Index used for addressing palette should be less than `Palette.DEFAULT_PALETTE_COUNT`, if index is greater than `DEFAULT_PALETTE_COUNT` `IllegalArgumentException` is thrown.
+
+> **Note:** Palette enum defines total of 28 named palettes that can be used to generate views without specifying colors.
+
+### 2.6 Using custom Palettes
+Custom Palettes can be used by creating new palette using one of the following constructor:
+
+```java
+Palette customPalette = new Palette(int c0, int c1, int c2, int c3, int c4, int c5, int c6, int c7, int c8);
+```
+
+or
+
+```java
+Palette customPalette = new Palette(int colors[]);
+```
+> Array based constructor will throw `IllegalArgumentException` if size of array is not exactly 9.
+
 ## 3. Performance analysis
 Few notes on performance of Trianglify
 * Performance takes a serious hit with decrease in cell size. Time complexity of the algorithm to generate triangles from grid of points is Ω(n*log(n)). Decreasing cell size increases n (number of points on the grid). 

--- a/app/src/main/java/com/sdsmdg/kd/trianglifyexample/MainActivity.java
+++ b/app/src/main/java/com/sdsmdg/kd/trianglifyexample/MainActivity.java
@@ -87,12 +87,12 @@ public class MainActivity extends AppCompatActivity {
         });
 
         paletteSeekBar = (SeekBar) findViewById(R.id.palette_seekbar);
-        paletteSeekBar.setMax(Palette.values().length-1);
+        paletteSeekBar.setMax(Palette.DEFAULT_PALETTE_COUNT - 1);
         paletteSeekBar.setProgress(Palette.indexOf(trianglifyView.getPalette()));
         paletteSeekBar.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
             @Override
             public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
-                trianglifyView.setPalette(Palette.values()[progress]);
+                trianglifyView.setPalette(Palette.getPalette(progress));
                 trianglifyView.invalidate();
             }
 
@@ -158,7 +158,7 @@ public class MainActivity extends AppCompatActivity {
     public void randomizeTrianglifyParameters(TrianglifyView trianglifyView){
         Random rnd = new Random(System.currentTimeMillis());
         trianglifyView.setCellSize(dpToPx(rnd.nextInt(10) + 35))
-                .setPalette(Palette.values()[rnd.nextInt(10)])
+                .setPalette(Palette.getPalette(rnd.nextInt(10)))
                 .setRandomColoring(rnd.nextInt(2) == 0)
                 .setFillTriangle(rnd.nextInt(2) == 0)
                 .setVariance(rnd.nextInt(60));
@@ -197,7 +197,7 @@ public class MainActivity extends AppCompatActivity {
 
     public void checkForColoringError(TrianglifyView trianglifyView) {
         if (!(trianglifyView.isFillTriangle() | trianglifyView.isDrawStrokeEnabled())) {
-            Toast.makeText(this, "view should atleast be set to draw strokes or fill triangles or both.", Toast.LENGTH_LONG).show();
+            Toast.makeText(this, "view should at least be set to draw strokes or fill triangles or both.", Toast.LENGTH_LONG).show();
         }
     }
 }

--- a/app/src/main/java/com/sdsmdg/kd/trianglifyexample/MainActivity.java
+++ b/app/src/main/java/com/sdsmdg/kd/trianglifyexample/MainActivity.java
@@ -158,7 +158,7 @@ public class MainActivity extends AppCompatActivity {
     public void randomizeTrianglifyParameters(TrianglifyView trianglifyView){
         Random rnd = new Random(System.currentTimeMillis());
         trianglifyView.setCellSize(dpToPx(rnd.nextInt(10) + 35))
-                .setPalette(Palette.getPalette(rnd.nextInt(10)))
+                .setPalette(Palette.getPalette(rnd.nextInt(28)))
                 .setRandomColoring(rnd.nextInt(2) == 0)
                 .setFillTriangle(rnd.nextInt(2) == 0)
                 .setVariance(rnd.nextInt(60));

--- a/trianglify/src/main/java/com/sdsmdg/kd/trianglify/models/Palette.java
+++ b/trianglify/src/main/java/com/sdsmdg/kd/trianglify/models/Palette.java
@@ -1,102 +1,180 @@
 package com.sdsmdg.kd.trianglify.models;
 
+/**
+ * <h1>Palette</h1>
+ * <b>Description : </b>
+ * Set of 9 colors that are used to color a triangulation. Palette contains few predefined color sets
+ * as well as method to perform operations on palette.
+ *
+ * @author kriti
+ * @since 18/3/17.
+ */
 
-import android.util.Log;
+public class Palette {
+    public static final int DEFAULT_PALETTE_COUNT = 28;
 
-public enum Palette {
+    public static final int YL_GN = 0;
+    public static final int YL = 1;
+    public static final int YL_GN_BU = 2;
+    public static final int GN_BU = 3;
+    public static final int BU_GN = 4;
+    public static final int PU_BU_GN = 5;
+    public static final int PU_BU = 6;
+    public static final int BU_PU = 7;
+    public static final int RD_PU = 8;
+    public static final int PU_RD = 9;
+    public static final int OR_RD = 10;
+    public static final int YL_OR_RD = 11;
+    public static final int YL_OR_BR = 12;
+    public static final int PURPLES = 13;
+    public static final int BLUES = 14;
+    public static final int GREENS = 15;
+    public static final int ORANGES = 16;
+    public static final int REDS = 17;
+    public static final int GREYS = 18;
+    public static final int PU_OR = 19;
+    public static final int BR_B_G = 20;
+    public static final int PU_RE_GN = 21;
+    public static final int PI_YE_G = 22;
+    public static final int RD_BU = 23;
+    public static final int RD_GY = 24;
+    public static final int RD_YL_BU = 25;
+    public static final int SPECTRAL = 26;
+    public static final int RD_YL_GN = 27;
 
-    Yl(0xFFFFE0, 0xFFFFCC, 0xFFFACD, 0xFFFF00, 0xFFEF00, 0xFFD300, 0xF8DE7E, 0xFFD700, 0xC3B091),
-    YlGn(0xffffe5, 0xf7fcb9, 0xd9f0a3, 0xaddd8e, 0x78c679, 0x41ab5d, 0x238443, 0x006837, 0x004529),
-    YlGnBu(0xffffd9, 0xedf8b1, 0xc7e9b4, 0x7fcdbb, 0x41b6c4, 0x1d91c0, 0x225ea8, 0x253494, 0x081d58),
-    GnBu(0xf7fcf0, 0xe0f3db, 0xccebc5, 0xa8ddb5, 0x7bccc4, 0x4eb3d3, 0x2b8cbe, 0x0868ac, 0x084081),
-    BuGn(0xf7fcfd, 0xe5f5f9, 0xccece6, 0x99d8c9, 0x66c2a4, 0x41ae76, 0x238b45, 0x006d2c, 0x00441b),
-    PuBuGn(0xfff7fb, 0xece2f0, 0xd0d1e6, 0xa6bddb, 0x67a9cf, 0x3690c0, 0x02818a, 0x016c59, 0x014636),
-    PuBu(0xfff7fb, 0xece7f2, 0xd0d1e6, 0xa6bddb, 0x74a9cf, 0x3690c0, 0x0570b0, 0x045a8d, 0x023858),
-    BuPu(0xf7fcfd, 0xe0ecf4, 0xbfd3e6, 0x9ebcda, 0x8c96c6, 0x8c6bb1, 0x88419d, 0x810f7c, 0x4d004b),
-    RdPu(0xfff7f3, 0xfde0dd, 0xfcc5c0, 0xfa9fb5, 0xf768a1, 0xdd3497, 0xae017e, 0x7a0177, 0x49006a),
-    PuRd(0xf7f4f9, 0xe7e1ef, 0xd4b9da, 0xc994c7, 0xdf65b0, 0xe7298a, 0xce1256, 0x980043, 0x67001f),
-    OrRd(0xfff7ec, 0xfee8c8, 0xfdd49e, 0xfdbb84, 0xfc8d59, 0xef6548, 0xd7301f, 0xb30000, 0x7f0000),
-    YlOrRd(0xffffcc, 0xffeda0, 0xfed976, 0xfeb24c, 0xfd8d3c, 0xfc4e2a, 0xe31a1c, 0xbd0026, 0x800026),
-    YlOrBr(0xffffe5, 0xfff7bc, 0xfee391, 0xfec44f, 0xfe9929, 0xec7014, 0xcc4c02, 0x993404, 0x662506),
-    Purples(0xfcfbfd, 0xefedf5, 0xdadaeb, 0xbcbddc, 0x9e9ac8, 0x807dba, 0x6a51a3, 0x54278f, 0x3f007d),
-    Blues(0xf7fbff, 0xdeebf7, 0xc6dbef, 0x9ecae1, 0x6baed6, 0x4292c6, 0x2171b5, 0x08519c, 0x08306b),
-    Greens(0xf7fcf5, 0xe5f5e0, 0xc7e9c0, 0xa1d99b, 0x74c476, 0x41ab5d, 0x238b45, 0x006d2c, 0x00441b),
-    Oranges(0xfff5eb, 0xfee6ce, 0xfdd0a2, 0xfdae6b, 0xfd8d3c, 0xf16913, 0xd94801, 0xa63603, 0x7f2704),
-    Reds(0xfff5f0, 0xfee0d2, 0xfcbba1, 0xfc9272, 0xfb6a4a, 0xef3b2c, 0xcb181d, 0xa50f15, 0x67000d),
-    Greys(0xffffff, 0xf0f0f0, 0xd9d9d9, 0xbdbdbd, 0x969696, 0x737373, 0x525252, 0x252525, 0x000000),
-    PuOr(0x7f3b08, 0xb35806, 0xe08214, 0xfdb863, 0xfee0b6, 0xf7f7f7, 0xd8daeb, 0xb2abd2, 0x8073ac),
-    BrBG(0x543005, 0x8c510a, 0xbf812d, 0xdfc27d, 0xf6e8c3, 0xf5f5f5, 0xc7eae5, 0x80cdc1, 0x35978f),
-    PRGn(0x40004b, 0x762a83, 0x9970ab, 0xc2a5cf, 0xe7d4e8, 0xf7f7f7, 0xd9f0d3, 0xa6dba0, 0x5aae61),
-    PiYG(0x8e0152, 0xc51b7d, 0xde77ae, 0xf1b6da, 0xfde0ef, 0xf7f7f7, 0xe6f5d0, 0xb8e186, 0x7fbc41),
-    RdBu(0x67001f, 0xb2182b, 0xd6604d, 0xf4a582, 0xfddbc7, 0xf7f7f7, 0xd1e5f0, 0x92c5de, 0x4393c3),
-    RdGy(0x67001f, 0xb2182b, 0xd6604d, 0xf4a582, 0xfddbc7, 0xffffff, 0xe0e0e0, 0xbababa, 0x878787),
-    RdYlBu(0xa50026, 0xd73027, 0xf46d43, 0xfdae61, 0xfee090, 0xffffbf, 0xe0f3f8, 0xabd9e9, 0x74add1),
-    Spectral(0x9e0142, 0xd53e4f, 0xf46d43, 0xfdae61, 0xfee08b, 0xffffbf, 0xe6f598, 0xabdda4, 0x66c2a5),
-    RdYlGn(0xa50026, 0xd73027, 0xf46d43, 0xfdae61, 0xfee08b, 0xffffbf, 0xd9ef8b, 0xa6d96a, 0x66bd63);
+    private int colors[];
 
-    private final int c0;
-    private final int c1;
-    private final int c2;
-    private final int c3;
-    private final int c4;
-    private final int c5;
-    private final int c6;
-    private final int c7;
-    private final int c8;
-
-    Palette(int c0, int c1, int c2, int c3, int c4, int c5, int c6, int c7, int c8) {
-        this.c0 = c0;
-        this.c1 = c1;
-        this.c2 = c2;
-        this.c3 = c3;
-        this.c4 = c4;
-        this.c5 = c5;
-        this.c6 = c6;
-        this.c7 = c7;
-        this.c8 = c8;
-    }
-
-    public int getColor(int index){
-        switch (index){
-            case 0:
-                return c0;
-            case 1:
-                return c1;
-            case 2:
-                return c2;
-            case 3:
-                return c3;
-            case 4:
-                return c4;
-            case 5:
-                return c5;
-            case 6:
-                return c6;
-            case 7:
-                return c7;
-            case 8:
-                return c8;
+    /**
+     * Return palette object corresponding to supplied value of paletteIndex, palette is constructed
+     * from a predefined set of colors
+     * @param palleteIndex Index of palette to return
+     * @return Palette object generated from predefined set of colors
+     */
+    public static Palette getPalette(int palleteIndex){
+        switch (palleteIndex){
+            case YL_GN:
+                return new Palette(0xFFFFE0, 0xFFFFCC, 0xFFFACD, 0xFFFF00, 0xFFEF00, 0xFFD300, 0xF8DE7E, 0xFFD700, 0xC3B091);
+            case YL:
+                return new Palette(0xffffe5, 0xf7fcb9, 0xd9f0a3, 0xaddd8e, 0x78c679, 0x41ab5d, 0x238443, 0x006837, 0x004529);
+            case YL_GN_BU:
+                return new Palette(0xffffd9, 0xedf8b1, 0xc7e9b4, 0x7fcdbb, 0x41b6c4, 0x1d91c0, 0x225ea8, 0x253494, 0x081d58);
+            case GN_BU:
+                return new Palette(0xf7fcf0, 0xe0f3db, 0xccebc5, 0xa8ddb5, 0x7bccc4, 0x4eb3d3, 0x2b8cbe, 0x0868ac, 0x084081);
+            case BU_GN:
+                return new Palette(0xf7fcfd, 0xe5f5f9, 0xccece6, 0x99d8c9, 0x66c2a4, 0x41ae76, 0x238b45, 0x006d2c, 0x00441b);
+            case PU_BU_GN:
+                return new Palette(0xfff7fb, 0xece2f0, 0xd0d1e6, 0xa6bddb, 0x67a9cf, 0x3690c0, 0x02818a, 0x016c59, 0x014636);
+            case PU_BU:
+                return new Palette(0xfff7fb, 0xece7f2, 0xd0d1e6, 0xa6bddb, 0x74a9cf, 0x3690c0, 0x0570b0, 0x045a8d, 0x023858);
+            case BU_PU:
+                return new Palette(0xf7fcfd, 0xe0ecf4, 0xbfd3e6, 0x9ebcda, 0x8c96c6, 0x8c6bb1, 0x88419d, 0x810f7c, 0x4d004b);
+            case RD_PU:
+                return new Palette(0xfff7f3, 0xfde0dd, 0xfcc5c0, 0xfa9fb5, 0xf768a1, 0xdd3497, 0xae017e, 0x7a0177, 0x49006a);
+            case PU_RD:
+                return new Palette(0xf7f4f9, 0xe7e1ef, 0xd4b9da, 0xc994c7, 0xdf65b0, 0xe7298a, 0xce1256, 0x980043, 0x67001f);
+            case OR_RD:
+                return new Palette(0xfff7ec, 0xfee8c8, 0xfdd49e, 0xfdbb84, 0xfc8d59, 0xef6548, 0xd7301f, 0xb30000, 0x7f0000);
+            case YL_OR_RD:
+                return new Palette(0xffffcc, 0xffeda0, 0xfed976, 0xfeb24c, 0xfd8d3c, 0xfc4e2a, 0xe31a1c, 0xbd0026, 0x800026);
+            case YL_OR_BR:
+                return new Palette(0xffffe5, 0xfff7bc, 0xfee391, 0xfec44f, 0xfe9929, 0xec7014, 0xcc4c02, 0x993404, 0x662506);
+            case PURPLES:
+                return new Palette(0xfcfbfd, 0xefedf5, 0xdadaeb, 0xbcbddc, 0x9e9ac8, 0x807dba, 0x6a51a3, 0x54278f, 0x3f007d);
+            case BLUES:
+                return new Palette(0xf7fbff, 0xdeebf7, 0xc6dbef, 0x9ecae1, 0x6baed6, 0x4292c6, 0x2171b5, 0x08519c, 0x08306b);
+            case GREENS:
+                return new Palette(0xf7fcf5, 0xe5f5e0, 0xc7e9c0, 0xa1d99b, 0x74c476, 0x41ab5d, 0x238b45, 0x006d2c, 0x00441b);
+            case ORANGES:
+                return new Palette(0xfff5eb, 0xfee6ce, 0xfdd0a2, 0xfdae6b, 0xfd8d3c, 0xf16913, 0xd94801, 0xa63603, 0x7f2704);
+            case REDS:
+                return new Palette(0xfff5f0, 0xfee0d2, 0xfcbba1, 0xfc9272, 0xfb6a4a, 0xef3b2c, 0xcb181d, 0xa50f15, 0x67000d);
+            case GREYS:
+                return new Palette(0xffffff, 0xf0f0f0, 0xd9d9d9, 0xbdbdbd, 0x969696, 0x737373, 0x525252, 0x252525, 0x000000);
+            case PU_OR:
+                return new Palette(0x7f3b08, 0xb35806, 0xe08214, 0xfdb863, 0xfee0b6, 0xf7f7f7, 0xd8daeb, 0xb2abd2, 0x8073ac);
+            case BR_B_G:
+                return new Palette(0x543005, 0x8c510a, 0xbf812d, 0xdfc27d, 0xf6e8c3, 0xf5f5f5, 0xc7eae5, 0x80cdc1, 0x35978f);
+            case PU_RE_GN:
+                return new Palette(0x40004b, 0x762a83, 0x9970ab, 0xc2a5cf, 0xe7d4e8, 0xf7f7f7, 0xd9f0d3, 0xa6dba0, 0x5aae61);
+            case PI_YE_G:
+                return new Palette(0x8e0152, 0xc51b7d, 0xde77ae, 0xf1b6da, 0xfde0ef, 0xf7f7f7, 0xe6f5d0, 0xb8e186, 0x7fbc41);
+            case RD_BU:
+                return new Palette(0x67001f, 0xb2182b, 0xd6604d, 0xf4a582, 0xfddbc7, 0xf7f7f7, 0xd1e5f0, 0x92c5de, 0x4393c3);
+            case RD_GY:
+                return new Palette(0x67001f, 0xb2182b, 0xd6604d, 0xf4a582, 0xfddbc7, 0xffffff, 0xe0e0e0, 0xbababa, 0x878787);
+            case RD_YL_BU:
+                return new Palette(0xa50026, 0xd73027, 0xf46d43, 0xfdae61, 0xfee090, 0xffffbf, 0xe0f3f8, 0xabd9e9, 0x74add1);
+            case SPECTRAL:
+                return new Palette(0x9e0142, 0xd53e4f, 0xf46d43, 0xfdae61, 0xfee08b, 0xffffbf, 0xe6f598, 0xabdda4, 0x66c2a5);
+            case RD_YL_GN:
+                return new Palette(0xa50026, 0xd73027, 0xf46d43, 0xfdae61, 0xfee08b, 0xffffbf, 0xd9ef8b, 0xa6d96a, 0x66bd63);
             default:
-                Log.i("Palette", "Invalid index");
-                break;
+                throw new IllegalArgumentException("Index should be less Palette.DEFAULT_PALETTE_COUNT");
         }
-        return c1;
     }
 
+    /**
+     * Returns index of palette object passed from list of palettes predefined in Palette
+     * @param palette Object for finding index
+     * @return Index from predefined pallete or -1 if not found
+     */
     public static int indexOf(Palette palette){
         int pos = -1;
-        for (int i = 0; i < Palette.values().length; i++){
-            if (Palette.values()[i] == palette) {
+        for (int i = 0; i < Palette.DEFAULT_PALETTE_COUNT; i++){
+            if (Palette.getPalette(i) == palette) {
                 pos = i;
             }
         }
         return  pos;
     }
 
-    public static void main(String[] args) {
-        if (args.length != 1) {
-            System.err.println("Usage: java Palette <colors>");
-            System.exit(-1);
+    public Palette(int c0, int c1, int c2, int c3, int c4, int c5, int c6, int c7, int c8) {
+        colors = new int[9];
+        colors[0] = c0;
+        colors[1] = c1;
+        colors[2] = c2;
+        colors[3] = c3;
+        colors[4] = c4;
+        colors[5] = c5;
+        colors[6] = c6;
+        colors[7] = c7;
+        colors[8] = c8;
+    }
+
+    public Palette(int colors[]) {
+        if (colors.length != 9) {
+            throw new IllegalArgumentException("Colors array length should exactly be 9");
+        }
+        this.colors = colors;
+    }
+
+    /**
+     * Returns color corresponding to index passed from the set of color for a palette
+     * @param index Index of color in set of color for current palette object
+     * @return color as int without alpha channel
+     */
+    public int getColor(int index){
+        switch (index){
+            case 0:
+                return colors[0];
+            case 1:
+                return colors[1];
+            case 2:
+                return colors[2];
+            case 3:
+                return colors[3];
+            case 4:
+                return colors[4];
+            case 5:
+                return colors[5];
+            case 6:
+                return colors[6];
+            case 7:
+                return colors[7];
+            case 8:
+                return colors[8];
+            default:
+                throw new IllegalArgumentException("Index should be less than 9");
         }
     }
 }

--- a/trianglify/src/main/java/com/sdsmdg/kd/trianglify/models/Palette.java
+++ b/trianglify/src/main/java/com/sdsmdg/kd/trianglify/models/Palette.java
@@ -44,14 +44,25 @@ public class Palette {
 
     private int[] colors;
 
+    public int[] getColors() {
+        return colors;
+    }
+
+    public void setColors(int[] colors) {
+        if (colors.length != 9) {
+            throw new IllegalArgumentException("Colors array length should exactly be 9");
+        }
+        this.colors = colors;
+    }
+
     /**
      * Return palette object corresponding to supplied value of paletteIndex, palette is constructed
      * from a predefined set of colors
-     * @param palleteIndex Index of palette to return
+     * @param paletteIndex Index of palette to return
      * @return Palette object generated from predefined set of colors
      */
-    public static Palette getPalette(int palleteIndex) {
-        switch (palleteIndex){
+    public static Palette getPalette(int paletteIndex) {
+        switch (paletteIndex){
             case YL_GN:
                 return new Palette(0xFFFFE0, 0xFFFFCC, 0xFFFACD, 0xFFFF00, 0xFFEF00, 0xFFD300, 0xF8DE7E, 0xFFD700, 0xC3B091);
             case YL:

--- a/trianglify/src/main/java/com/sdsmdg/kd/trianglify/models/Palette.java
+++ b/trianglify/src/main/java/com/sdsmdg/kd/trianglify/models/Palette.java
@@ -33,9 +33,9 @@ public class Palette {
     public static final int REDS = 17;
     public static final int GREYS = 18;
     public static final int PU_OR = 19;
-    public static final int BR_B_G = 20;
-    public static final int PU_RE_GN = 21;
-    public static final int PI_YE_G = 22;
+    public static final int BR_BL = 20;
+    public static final int PU_RD_GN = 21;
+    public static final int PI_YL_GN = 22;
     public static final int RD_BU = 23;
     public static final int RD_GY = 24;
     public static final int RD_YL_BU = 25;
@@ -62,10 +62,10 @@ public class Palette {
      * @return Palette object generated from predefined set of colors
      */
     public static Palette getPalette(int paletteIndex) {
-        switch (paletteIndex){
-            case YL_GN:
-                return new Palette(0xFFFFE0, 0xFFFFCC, 0xFFFACD, 0xFFFF00, 0xFFEF00, 0xFFD300, 0xF8DE7E, 0xFFD700, 0xC3B091);
+        switch (paletteIndex) {
             case YL:
+                return new Palette(0xffffe0, 0xffffcc, 0xfffacd, 0xffff00, 0xffef00, 0xffd300, 0xf8de7e, 0xffd700, 0xc3b091);
+            case YL_GN:
                 return new Palette(0xffffe5, 0xf7fcb9, 0xd9f0a3, 0xaddd8e, 0x78c679, 0x41ab5d, 0x238443, 0x006837, 0x004529);
             case YL_GN_BU:
                 return new Palette(0xffffd9, 0xedf8b1, 0xc7e9b4, 0x7fcdbb, 0x41b6c4, 0x1d91c0, 0x225ea8, 0x253494, 0x081d58);
@@ -103,11 +103,11 @@ public class Palette {
                 return new Palette(0xffffff, 0xf0f0f0, 0xd9d9d9, 0xbdbdbd, 0x969696, 0x737373, 0x525252, 0x252525, 0x000000);
             case PU_OR:
                 return new Palette(0x7f3b08, 0xb35806, 0xe08214, 0xfdb863, 0xfee0b6, 0xf7f7f7, 0xd8daeb, 0xb2abd2, 0x8073ac);
-            case BR_B_G:
+            case BR_BL:
                 return new Palette(0x543005, 0x8c510a, 0xbf812d, 0xdfc27d, 0xf6e8c3, 0xf5f5f5, 0xc7eae5, 0x80cdc1, 0x35978f);
-            case PU_RE_GN:
+            case PU_RD_GN:
                 return new Palette(0x40004b, 0x762a83, 0x9970ab, 0xc2a5cf, 0xe7d4e8, 0xf7f7f7, 0xd9f0d3, 0xa6dba0, 0x5aae61);
-            case PI_YE_G:
+            case PI_YL_GN:
                 return new Palette(0x8e0152, 0xc51b7d, 0xde77ae, 0xf1b6da, 0xfde0ef, 0xf7f7f7, 0xe6f5d0, 0xb8e186, 0x7fbc41);
             case RD_BU:
                 return new Palette(0x67001f, 0xb2182b, 0xd6604d, 0xf4a582, 0xfddbc7, 0xf7f7f7, 0xd1e5f0, 0x92c5de, 0x4393c3);
@@ -152,7 +152,7 @@ public class Palette {
         colors[8] = c8;
     }
 
-    public Palette(int colors[]) {
+    public Palette(int[] colors) {
         if (colors.length != 9) {
             throw new IllegalArgumentException("Colors array length should exactly be 9");
         }
@@ -165,7 +165,7 @@ public class Palette {
      * @return color as int without alpha channel
      */
     public int getColor(int index) {
-        switch (index){
+        switch (index) {
             case 0:
                 return colors[0];
             case 1:

--- a/trianglify/src/main/java/com/sdsmdg/kd/trianglify/models/Palette.java
+++ b/trianglify/src/main/java/com/sdsmdg/kd/trianglify/models/Palette.java
@@ -42,7 +42,7 @@ public class Palette {
     public static final int SPECTRAL = 26;
     public static final int RD_YL_GN = 27;
 
-    private int colors[];
+    private int[] colors;
 
     /**
      * Return palette object corresponding to supplied value of paletteIndex, palette is constructed
@@ -50,7 +50,7 @@ public class Palette {
      * @param palleteIndex Index of palette to return
      * @return Palette object generated from predefined set of colors
      */
-    public static Palette getPalette(int palleteIndex){
+    public static Palette getPalette(int palleteIndex) {
         switch (palleteIndex){
             case YL_GN:
                 return new Palette(0xFFFFE0, 0xFFFFCC, 0xFFFACD, 0xFFFF00, 0xFFEF00, 0xFFD300, 0xF8DE7E, 0xFFD700, 0xC3B091);
@@ -118,9 +118,9 @@ public class Palette {
      * @param palette Object for finding index
      * @return Index from predefined pallete or -1 if not found
      */
-    public static int indexOf(Palette palette){
+    public static int indexOf(Palette palette) {
         int pos = -1;
-        for (int i = 0; i < Palette.DEFAULT_PALETTE_COUNT; i++){
+        for (int i = 0; i < Palette.DEFAULT_PALETTE_COUNT; i++) {
             if (Palette.getPalette(i) == palette) {
                 pos = i;
             }
@@ -153,7 +153,7 @@ public class Palette {
      * @param index Index of color in set of color for current palette object
      * @return color as int without alpha channel
      */
-    public int getColor(int index){
+    public int getColor(int index) {
         switch (index){
             case 0:
                 return colors[0];

--- a/trianglify/src/main/java/com/sdsmdg/kd/trianglify/views/TrianglifyView.java
+++ b/trianglify/src/main/java/com/sdsmdg/kd/trianglify/views/TrianglifyView.java
@@ -59,7 +59,7 @@ public class TrianglifyView extends View implements TrianglifyViewInterface{
             fillTriangle = typedArray.getBoolean(R.styleable.TrianglifyView_fillTriangle, true);
             drawStroke = typedArray.getBoolean(R.styleable.TrianglifyView_fillStrokes, false);
             paletteNumber = typedArray.getInt(R.styleable.TrianglifyView_palette, 0);
-            palette = Palette.values()[paletteNumber];
+            palette = Palette.getPalette(paletteNumber);
             typeGrid = GRID_RECTANGLE;
             randomColoring = typedArray.getBoolean(R.styleable.TrianglifyView_randomColoring, false);
         }finally {


### PR DESCRIPTION
[Fixes #17]
This PR 
* Adds support for custom palette by changing API for setting palette from `trianglifyView.setPalette(Palette.Spectral)` to `trianglifyView.setPalette(Palette.getPalette(Palette.Spectral))`
* Re structure `Palette.java` from and enum to class
* Configures Sputnik style check
