### PR TITLE
Remove allowBackup and supportsRtl attributes from AndroidManifest

### DIFF
--- a/trianglify/src/main/AndroidManifest.xml
+++ b/trianglify/src/main/AndroidManifest.xml
@@ -1,8 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.sdsmdg.kd.trianglify">
 
-    <application android:allowBackup="true" android:label="@string/app_name"
-        android:supportsRtl="true">
+    <application android:label="@string/app_name">
 
     </application>
 </manifest>


### PR DESCRIPTION
These attributes are not required by the library and may create
conflicts with the manifest of the applications which use this library.

This commit fixes #57.